### PR TITLE
Bringing compose versions into alignment (CSD-5433)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.6'
 
 services:
 


### PR DESCRIPTION
Bringing main compose up to version 3.6 to match our example override