### PR TITLE
CSD-4976 Make sure structure info CSV still works

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ docker-compose -f docker-compose.yml -f docker-compose.db-config.yml up -d
 
 For more information see the [Docker volumes documentation](https://docs.docker.com/compose/compose-file/#volumes).
 
+## Associated Structure Links Configuration
+
+On-Site WebCSD can be configured to display links associated with a structure, e.g DOI links or File links. To do this you will need a CSV file containing structures with their associated data and any files you may want to download. The CSV file belongs in `webcsdbackend` and is configured in the `environment` section. Any related files belong to `webcsd` where the location is configured in the `volumes` section. It is important to note that any file links set up in the CSV file, must point to the correct location of these files, otherwise the file will not download when the link is clicked.
+
 ## Usage
 
 To access the WebCSD service locally go to http://localhost in a browser.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3.6'
 
 services:
-
   webcsd:
     environment:
       - CsdRepository__ServiceLocation=webcsdbackend
@@ -12,7 +11,8 @@ services:
     ports:
       - 80:80
     volumes:
-      - ./userdata:/app/OnSite      
+      - ./userdata:/app/OnSite
+      - ./structure-files:/structure-files
 
   webcsdbackend:
     depends_on:
@@ -20,13 +20,14 @@ services:
       - csd-request-entry
     image: ccdcrepository.azurecr.io/webcsdbackend:0.1.6
     environment:
+      - ServiceSettings__StructureInfoLocation=/csd-data/structure-links.csv
       - CCDC_LICENSING_CONFIGURATION=${CCDC_LICENCING_CONFIGURATION};
 
   redis:
     image: redis
     restart: always
     command: redis-server --requirepass ${CSD_CACHE_PASSWORD}
-    
+
   database-server:
     image: ccdcrepository.azurecr.io/csd-database:2022.1.0.alpha2
     restart: always


### PR DESCRIPTION
Added environment/volume settings for webcsdbackend/webcsd, to support the old Structure Info functionality
Added some readme text...which I hope makes sense.
![image](https://user-images.githubusercontent.com/65163812/188934193-c28f8edd-68e4-48b0-b84f-a2fa7410c1d9.png)
