### PR TITLE
CSD-5728 Updated readme file with instructions for adding HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ docker-compose up -d
 docker-compose -f docker-compose.yml -f docker-compose.db-config.yml up -d
 ```
 
+### Running WebCSD under SSL
+
+To run WebCSD using HTTPS, you will need to do the following:
+
+1. Obtain a certificate and store it in a folder that can be referenced in the volumes section (path/to/certificate).
+
+2. Update sections of `webcsd` to add HTTPS support. An example of what to add and in which section, is shown below:
+
+```
+  webcsd:
+    environment:
+      - ASPNETCORE_URLS=https://+:443;http://+:80
+      - ASPNETCORE_Kestrel__Certificates__Default__Password=<password used to create certificate>
+      - ASPNETCORE_Kestrel__Certificates__Default__Path=/container/path/certificate.pfx
+
+    ports:
+      - 443:443
+
+    volumes:
+      - /path/to/certificate:/container/path:ro   # with read-only attributes (:ro)
+```
+
 ### Offline Installation
 
 This release will be only available online, if this is a problem please contact us. In the future we plan on supporting offline installs.


### PR DESCRIPTION
Using this page as a guide: https://docs.microsoft.com/en-us/aspnet/core/security/docker-compose-https?view=aspnetcore-6.0

I have successfully created a local dev certificate and can now add this to the docker compose file and run it in HTTPS mode.

The readme file text tries to be as generic as possible. Hopefully it makes sense?

![image](https://user-images.githubusercontent.com/65163812/189118099-da661a6d-9d55-4148-8eb1-e407c9fa8599.png)

